### PR TITLE
Updated readme and added release rockspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Installation
 
 or
 
-    luarocks install --local rockspec/resty.smtp-0.0.3-1.rockspec
+    luarocks install resty-smtp
 
 
 
@@ -141,5 +141,3 @@ Known Issues
 * Only work with LuaJIT 2.x now, because the codebase relies on `pcall`
   massively and lua-nginx-module does not work well with standard Lua 5.1 VM
   under this situation. See [Known Issues](http://wiki.nginx.org/HttpLuaModule#Lua_Coroutine_Yielding.2FResuming)
-
-

--- a/rockspec/resty.smtp-1.0rc1-1.rockspec
+++ b/rockspec/resty.smtp-1.0rc1-1.rockspec
@@ -1,0 +1,37 @@
+rockspec_format = "1.0"
+package = "resty-smtp"
+version = "1.0rc1-1"
+
+description = {
+    summary= "A smtp module for lua-nginx-module",
+    detailed = [[]],
+    license= "BSD",
+    homepage= "https://github.com/athersharif/lua-resty-smtp",
+    maintainer= "Ather Sharif <ather.sharif@gmail.com>",
+}
+
+dependencies = {
+    "lua ~> 5.1"
+}
+
+-- contains information on how to fetch sources to build this rock.
+source = {
+    url= "git://github.com/athersharif/lua-resty-smtp.git",
+    branch= "master"
+}
+
+-- contains all information pertaining how to build this rock
+build = {
+    type = "builtin",
+    modules =
+    {
+      ["resty.smtp"] = "lib/resty/smtp.lua",
+      ["resty.smtp.base64"] = "lib/resty/smtp/base64.lua",
+      ["resty.smtp.ltn12"] = "lib/resty/smtp/ltn12.lua",
+      ["resty.smtp.mime-core"] = "lib/resty/smtp/mime-core.lua",
+      ["resty.smtp.mime"] = "lib/resty/smtp/mime.lua",
+      ["resty.smtp.misc"] = "lib/resty/smtp/misc.lua",
+      ["resty.smtp.qp"] = "lib/resty/smtp/qp.lua",
+      ["resty.smtp.tp"] = "lib/resty/smtp/tp.lua",
+    },
+}


### PR DESCRIPTION
Created a release rockspec, which loses the originally set dependency on the `LUA_SHAREDIR` environment variable. The rockspec is accessible via `luarocks install resty-smtp`, which fixes the original luarocks url. 